### PR TITLE
release: prerelease stays off main + rename development→develop

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,7 +1,7 @@
 name: Bump Version
 
 # The ONLY place the version is bumped. Increments Pub/PubVersion.json (+ Directory.Build.props),
-# commits, and fast-forwards development + main (no force). The CHANGELOG is hand-maintained and is
+# commits, and fast-forwards develop + main (no force). The CHANGELOG is hand-maintained and is
 # never rewritten here. Bumping in CI (not on a developer's machine) avoids version-file conflicts
 # between developers. See Pub/RELEASE-STRATEGY.md.
 #
@@ -33,12 +33,12 @@ jobs:
   bump:
     runs-on: ubuntu-latest
     permissions:
-      contents: write   # push the bump commit to development + main
+      contents: write   # push the bump commit to develop + main
       actions: write    # dispatch the downstream publish workflow(s)
     steps:
       - uses: actions/checkout@v5
         with:
-          ref: development
+          ref: develop
           fetch-depth: 0            # need history to fast-forward main
           persist-credentials: true # so the push uses github.token
       - name: Configure git identity
@@ -55,10 +55,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh workflow run client_publish.yml --repo "${{ github.repository }}" --ref development -f publish_release=true -f build_android=true -f rollout="${{ github.event.inputs.rollout }}"
+          gh workflow run client_publish.yml --repo "${{ github.repository }}" --ref develop -f publish_release=true -f build_android=true -f rollout="${{ github.event.inputs.rollout }}"
       - name: Dispatch NuGet publish
         if: ${{ github.event.inputs.then_publish_nugets == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh workflow run nuget_publish.yml --repo "${{ github.repository }}" --ref development
+          gh workflow run nuget_publish.yml --repo "${{ github.repository }}" --ref develop

--- a/.github/workflows/client_android_build.yml
+++ b/.github/workflows/client_android_build.yml
@@ -22,7 +22,7 @@ on:
       ref:
         description: "Branch or commit to build"
         required: false
-        default: "development"
+        default: "develop"
 
 jobs:
   build-android:

--- a/.github/workflows/client_linux_build.yml
+++ b/.github/workflows/client_linux_build.yml
@@ -16,7 +16,7 @@ on:
       ref:
         description: "Branch or commit to build"
         required: false
-        default: "development"
+        default: "develop"
       publish_release:
         description: "Create a GitHub release with the built assets"
         type: boolean

--- a/Pub/Bump.ps1
+++ b/Pub/Bump.ps1
@@ -1,7 +1,7 @@
 # The ONE place the version is bumped.
 #
 # Increments Pub/PubVersion.json (+ stamps Src/Directory.Build.props), commits, and pushes to
-# `development` (the prerelease line). On a STABLE bump it ALSO fast-forwards `main` (the release line),
+# `develop` (the prerelease line). On a STABLE bump it ALSO fast-forwards `main` (the release line),
 # no --force; a prerelease bump leaves `main` untouched. Intended to run in CI (.github/workflows/bump.yml)
 # so the bump never happens on a developer's machine — that avoids version-file conflicts between developers.
 # Can also be run locally for a manual bump. See Pub/RELEASE-STRATEGY.md.
@@ -36,8 +36,8 @@ if ($noPush) {
 	return;
 }
 
-# Commit the version + changelog, then push. The PRERELEASE line is `development`; `main` is the STABLE
-# release line. A prerelease bump advances `development` ONLY — it must never touch `main` (prereleases
+# Commit the version + changelog, then push. The PRERELEASE line is `develop`; `main` is the STABLE
+# release line. A prerelease bump advances `develop` ONLY — it must never touch `main` (prereleases
 # go to TestFlight / Play alpha, not the App Store / Play production). A STABLE bump advances both,
 # fast-forwarding `main` WITHOUT --force (a forced rewrite of main breaks every fork/clone that tracks
 # it; a non-fast-forward rejection signals a real divergence to reconcile by hand rather than overwrite).
@@ -45,8 +45,8 @@ git --git-dir=$gitDir --work-tree=$solutionDir add -A;
 git --git-dir=$gitDir --work-tree=$solutionDir commit -m "Publish $versionTag";
 if ($LASTEXITCODE -ne 0) { throw "git commit failed (exit $LASTEXITCODE)"; }
 
-git --git-dir=$gitDir --work-tree=$solutionDir push origin HEAD:development;
-if ($LASTEXITCODE -ne 0) { throw "git push to development failed (exit $LASTEXITCODE)"; }
+git --git-dir=$gitDir --work-tree=$solutionDir push origin HEAD:develop;
+if ($LASTEXITCODE -ne 0) { throw "git push to develop failed (exit $LASTEXITCODE)"; }
 
 if ($prerelease) {
 	Write-Host "Prerelease bump: leaving 'main' untouched (main advances only on a stable release)." -ForegroundColor Yellow;

--- a/Pub/Bump.ps1
+++ b/Pub/Bump.ps1
@@ -1,8 +1,9 @@
 # The ONE place the version is bumped.
 #
-# Increments Pub/PubVersion.json (+ stamps Src/Directory.Build.props), commits, and fast-forwards
-# BOTH development and main (no --force). Intended to run in CI (.github/workflows/bump.yml) so the
-# bump never happens on a developer's machine — that avoids version-file conflicts between developers.
+# Increments Pub/PubVersion.json (+ stamps Src/Directory.Build.props), commits, and pushes to
+# `development` (the prerelease line). On a STABLE bump it ALSO fast-forwards `main` (the release line),
+# no --force; a prerelease bump leaves `main` untouched. Intended to run in CI (.github/workflows/bump.yml)
+# so the bump never happens on a developer's machine — that avoids version-file conflicts between developers.
 # Can also be run locally for a manual bump. See Pub/RELEASE-STRATEGY.md.
 #
 # The CHANGELOG is maintained BY HAND — this never rewrites it. Put the next release's notes under a
@@ -35,9 +36,11 @@ if ($noPush) {
 	return;
 }
 
-# Commit the version + changelog, then fast-forward development and main WITHOUT --force. A forced
-# rewrite of main breaks every fork/clone that tracks it; a non-fast-forward rejection here signals a
-# real divergence to reconcile by hand rather than overwrite.
+# Commit the version + changelog, then push. The PRERELEASE line is `development`; `main` is the STABLE
+# release line. A prerelease bump advances `development` ONLY — it must never touch `main` (prereleases
+# go to TestFlight / Play alpha, not the App Store / Play production). A STABLE bump advances both,
+# fast-forwarding `main` WITHOUT --force (a forced rewrite of main breaks every fork/clone that tracks
+# it; a non-fast-forward rejection signals a real divergence to reconcile by hand rather than overwrite).
 git --git-dir=$gitDir --work-tree=$solutionDir add -A;
 git --git-dir=$gitDir --work-tree=$solutionDir commit -m "Publish $versionTag";
 if ($LASTEXITCODE -ne 0) { throw "git commit failed (exit $LASTEXITCODE)"; }
@@ -45,5 +48,10 @@ if ($LASTEXITCODE -ne 0) { throw "git commit failed (exit $LASTEXITCODE)"; }
 git --git-dir=$gitDir --work-tree=$solutionDir push origin HEAD:development;
 if ($LASTEXITCODE -ne 0) { throw "git push to development failed (exit $LASTEXITCODE)"; }
 
-git --git-dir=$gitDir --work-tree=$solutionDir push origin HEAD:main;
-if ($LASTEXITCODE -ne 0) { throw "git push to main failed (non-fast-forward? reconcile by hand, do not force) (exit $LASTEXITCODE)"; }
+if ($prerelease) {
+	Write-Host "Prerelease bump: leaving 'main' untouched (main advances only on a stable release)." -ForegroundColor Yellow;
+}
+else {
+	git --git-dir=$gitDir --work-tree=$solutionDir push origin HEAD:main;
+	if ($LASTEXITCODE -ne 0) { throw "git push to main failed (non-fast-forward? reconcile by hand, do not force) (exit $LASTEXITCODE)"; }
+}

--- a/Pub/Client/PublishByGithub.ps1
+++ b/Pub/Client/PublishByGithub.ps1
@@ -1,6 +1,6 @@
 # Triggers a FULL release on GitHub Actions by dispatching the "Bump Version" workflow (bump.yml),
 # which is the single writer of the version: it bumps Pub/PubVersion.json (the CHANGELOG is
-# hand-maintained, never rewritten), commits, fast-forwards development + main, and then chains the
+# hand-maintained, never rewritten), commits, fast-forwards develop + main, and then chains the
 # client publish (Linux + Windows +
 # Android + Google Play + GitHub release) AND the NuGet publish against the freshly bumped commit.
 #
@@ -114,7 +114,7 @@ if (-not $yes) {
 
 gh workflow run $workflowFile `
 	--repo $repo `
-	--ref development `
+	--ref develop `
 	-f "prerelease=$($prerelease.ToString().ToLower())" `
 	-f "rollout=$rollout" `
 	-f "then_publish=true" `

--- a/Pub/Connect/PublishByGithub.ps1
+++ b/Pub/Connect/PublishByGithub.ps1
@@ -3,8 +3,8 @@
 #
 # Two steps, one command:
 #   1. Bump the MONOREPO in CI (bump.yml) with client-publish AND nuget OFF — so PubVersion.json +
-#      CHANGELOG advance and are pushed to development + main. Waits for it to finish.
-#   2. Dispatch connect_publish.yml in the CONNECT repo (ref = development) to build Connect from the
+#      CHANGELOG advance and are pushed to develop + main. Waits for it to finish.
+#   2. Dispatch connect_publish.yml in the CONNECT repo (ref = develop) to build Connect from the
 #      freshly bumped code and release it there. No bump and no NuGet happen in the Connect repo.
 #
 # Usage:
@@ -75,8 +75,8 @@ $rolloutText = if ($prerelease) { "n/a (alpha ships complete)" } else { "$rollou
 
 Write-Host "";
 Write-Host "*** Release Connect via GitHub Actions" -BackgroundColor Blue;
-Write-Host "  1) bump monorepo : $monoRepo   (publish OFF, nuget OFF -> push development + main)";
-Write-Host "  2) publish Connect: $connectRepo   (build from monorepo development, release there)";
+Write-Host "  1) bump monorepo : $monoRepo   (publish OFF, nuget OFF -> push develop + main)";
+Write-Host "  2) publish Connect: $connectRepo   (build from monorepo develop, release there)";
 Write-Host "  type             : $releaseKind";
 Write-Host "  Play audience    : $rolloutText";
 Write-Host "";
@@ -93,7 +93,7 @@ if (-not $yes) {
 Write-Host "Dispatching bump on $monoRepo ..." -ForegroundColor Cyan;
 gh workflow run bump.yml `
 	--repo $monoRepo `
-	--ref development `
+	--ref develop `
 	-f "prerelease=$($prerelease.ToString().ToLower())" `
 	-f "then_publish=false" `
 	-f "then_publish_nugets=false";
@@ -106,12 +106,12 @@ Write-Host "Waiting for the bump run ($bumpRun) to finish ..." -ForegroundColor 
 gh run watch $bumpRun --repo $monoRepo --exit-status;
 if ($LASTEXITCODE -ne 0) { throw "The bump run failed; Connect was NOT dispatched. Fix the bump, then retry."; }
 
-# --- Step 2: dispatch the Connect release (build from the freshly bumped development) -----------
+# --- Step 2: dispatch the Connect release (build from the freshly bumped develop) -----------
 Write-Host "Dispatching Connect release on $connectRepo ..." -ForegroundColor Cyan;
 gh workflow run connect_publish.yml `
 	--repo $connectRepo `
 	--ref main `
-	-f "ref=development" `
+	-f "ref=develop" `
 	-f "build_android=true" `
 	-f "publish_play=true" `
 	-f "publish_release=true" `

--- a/Pub/RELEASE-STRATEGY.md
+++ b/Pub/RELEASE-STRATEGY.md
@@ -15,7 +15,7 @@ The repo is one large solution (~70 projects, ~60 of them NuGet libraries) plus 
    all ~60 NuGets even when they did not change — pure churn.
 2. **The bump ran on a developer's machine** (inside `Publish.ps1 -bump`), so two people releasing
    could collide on the version file.
-3. **`main` was updated with `push origin development:main --force`**, which rewrites `main`'s
+3. **`main` was updated with `push origin develop:main --force`**, which rewrites `main`'s
    history and breaks every fork/clone that tracks it.
 4. **NuGet-in-development confusion**: "if I change a project, do I have to wait for a NuGet build?"
 
@@ -39,14 +39,15 @@ Rule of thumb: **same repo = ProjectReference, third-party = PackageReference, r
 
 1. **CI owns the bump.** A dedicated `bump` action ([.github/workflows/bump.yml](../.github/workflows/bump.yml)
    → [Pub/Bump.ps1](Bump.ps1)) increments `PubVersion.json` (+ `Directory.Build.props`), commits,
-   and fast-forwards `development` + `main`. The CHANGELOG is hand-maintained (leading `# Latest`
-   section) and never rewritten by CI. Local machines never bump → no cross-developer
-   conflicts. It can optionally chain straight into the client publish and/or NuGet publish. **(Done.)**
-2. **No force-push to `main`; fast-forward only.** [Pub/Bump.ps1](Bump.ps1) pushes `HEAD:development`
-   then `HEAD:main` **without `--force`** (the old `CommitAndPushToMainRepo`/`CommitAndSyncMainRepo`
-   helpers in Common.ps1 were removed).
-   `main` only tracks `development`, so this is a clean fast-forward; a rejection signals a real
-   divergence to reconcile by hand rather than overwrite. Protects forkers. **(Done.)**
+   and pushes to `develop` (a stable bump additionally fast-forwards `main`). The CHANGELOG is
+   hand-maintained (leading `# Latest` section) and never rewritten by CI. Local machines never bump →
+   no cross-developer conflicts. It can optionally chain straight into the client publish and/or NuGet publish. **(Done.)**
+2. **`develop` is the prerelease line; `main` is the stable/release line.** [Pub/Bump.ps1](Bump.ps1)
+   always pushes `HEAD:develop`; on a **stable** bump it ALSO fast-forwards `HEAD:main` **without
+   `--force`** (a **prerelease** bump leaves `main` untouched — prereleases ship to TestFlight / Play
+   alpha, not the App Store / Play production). `main` only ever fast-forwards from `develop`, so it is
+   a clean fast-forward; a rejection signals a real divergence to reconcile by hand rather than
+   overwrite. Protects forkers. **(Done.)**
 3. **NuGet is always a stable Release version.** Packing is `-c Release`; the version does not get a
    `-prerelease` suffix from the app flag ([Pub/Lib/PublishNugets.ps1](Lib/PublishNugets.ps1)).
    One clean library version line, decoupled from app prereleases. (The `smoke` input is the only
@@ -98,10 +99,10 @@ These were considered and intentionally **not** done now. Revisit if the pain gr
    Commit + push as normal work.
 2. Run the **Bump Version** workflow (`bump.yml`). Choose `prerelease` on/off. Optionally tick
    `then_publish` (create the GitHub release) and/or `then_publish_nugets`. It bumps the version once
-   (`PubVersion.json` + `Directory.Build.props`) and fast-forwards `development` + `main`. It does
-   **not** touch the changelog.
+   (`PubVersion.json` + `Directory.Build.props`) and pushes `develop` (a stable bump also fast-forwards
+   `main`; a prerelease bump does not). It does **not** touch the changelog.
 3. If you didn't chain them, dispatch **Publish Client** (`client_publish.yml`) and/or **Publish
-   NuGet Packages** (`nuget_publish.yml`) against `development` yourself — both are standalone.
+   NuGet Packages** (`nuget_publish.yml`) against `develop` yourself — both are standalone.
 
 `Pub/Client/Publish.ps1` is now **build-only** for local smoke testing (no bump, no distribute, no
 push).
@@ -171,7 +172,7 @@ unrelated and remain — they are real build logic invoked directly by the app C
 - **CI-owned bump**: new [Pub/Bump.ps1](Bump.ps1) + [.github/workflows/bump.yml](../.github/workflows/bump.yml).
 - **Standalone NuGet publishing**: new [.github/workflows/nuget_publish.yml](../.github/workflows/nuget_publish.yml).
 - [Pub/Lib/Common.ps1](Lib/Common.ps1) — the local commit-to-main helpers were removed; `Pub/Bump.ps1`
-  owns the fast-forward push to `development` + `main` (no `--force`).
+  owns the push to `develop` (and the fast-forward to `main` on a stable bump, no `--force`).
 - **NuGet publish is one parallel pack pass** ([Pub/Lib/PublishNugets.ps1](Lib/PublishNugets.ps1))
   driven by `IsPackable` discovery; the old per-project `Pub/Lib/PublishNuget.ps1` was removed. Version
   is stable `X.Y.Z` except under the `smoke` input.


### PR DESCRIPTION
Two coupled release-pipeline changes, ahead of enabling the iOS prerelease publish:

### 1. `develop` = prerelease line, `main` = stable line
`Bump.ps1` now pushes a **prerelease** bump to `develop` **only** — it never touches `main`. A **stable** bump still fast-forwards `main` (no `--force`). Prereleases go to TestFlight / Play alpha; `main` only advances for App Store / Play production releases.

### 2. Rename `development` → `develop`
All branch references updated: `bump.yml` (`ref` + dispatch `--ref` ×2), `client_linux_build.yml` / `client_android_build.yml` (`default`), `Bump.ps1` (`HEAD:develop`), `Pub/Client|Connect/PublishByGithub.ps1`, `RELEASE-STRATEGY.md`. Prose ("during development") left as-is.

**Merge, then the `development` branch is renamed to `develop` on GitHub** (auto-retargets open PRs). The Connect repo's `connect_publish.yml` ref default is updated in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)