### PR TITLE
docs(legal): fix policy history link and contact channel

### DIFF
--- a/docs/legal/end-user/vpnhood-client-privacy-policy.md
+++ b/docs/legal/end-user/vpnhood-client-privacy-policy.md
@@ -66,8 +66,8 @@ The app lets you send us feedback, a rating, or a diagnostic log file to help so
 
 ## Changes to This Privacy Policy
 
-We may update this policy from time to time; the current version is always available on this page, and changes take effect when posted here. Substantive changes are also visible in the [VpnHood repository history](https://github.com/vpnhood/VpnHood), where this policy is maintained.
+We may update this policy from time to time; the current version is always available on this page, and changes take effect when posted here. Every revision is recorded in our open-source repository — see the [change history of this policy](https://github.com/vpnhood/VpnHood/commits/develop/docs/legal/end-user/vpnhood-client-privacy-policy.md).
 
 ## Contact Us
 
-Questions about this policy can be raised on our [GitHub repository](https://github.com/vpnhood/VpnHood/issues).
+Questions about this policy: [support@vpnhood.com](mailto:support@vpnhood.com)

--- a/docs/legal/end-user/vpnhood-connect-privacy-policy.md
+++ b/docs/legal/end-user/vpnhood-connect-privacy-policy.md
@@ -105,8 +105,8 @@ The app lets you send us feedback, a rating, or a diagnostic log file to help so
 
 ## Changes to This Privacy Policy
 
-We may update this policy from time to time; the current version is always available on this page, and changes take effect when posted here. Substantive changes are also visible in the [VpnHood repository history](https://github.com/vpnhood/VpnHood), where this policy is maintained.
+We may update this policy from time to time; the current version is always available on this page, and changes take effect when posted here. Every revision is recorded in our open-source repository — see the [change history of this policy](https://github.com/vpnhood/VpnHood/commits/develop/docs/legal/end-user/vpnhood-connect-privacy-policy.md).
 
 ## Contact Us
 
-Questions about this policy can be raised on our [GitHub repository](https://github.com/vpnhood/VpnHood/issues).
+Questions about this policy: [support@vpnhood.com](mailto:support@vpnhood.com)


### PR DESCRIPTION
Two link corrections in the published CLIENT and CONNECT privacy policies.

**Changes section** promised a change history but linked the repository root, so a reader looking for *what changed* landed on a code homepage. Each policy now links its own commit log on `develop`:
`https://github.com/vpnhood/VpnHood/commits/develop/docs/legal/end-user/<slug>.md`
The file name is the website slug and must not be renamed (see the folder README), so this deep link is exactly as stable as the public URL.

**Contact Us** pointed at the public issue tracker — the wrong channel for someone asking about their own data. Now `support@vpnhood.com`, the address already published in both store listings.

No change to what the apps collect, so the `Effective:` date is unchanged.

After merge, the site needs a `jekyll.yml` run to pick this up (it syncs the policies from `develop` at build time); it will otherwise land on the next scheduled build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)